### PR TITLE
项目再windows运行的解决方案

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ $ npm start
 * 已修复 2016年09月05日15:03:27
 * 因为使用了 node-sass ，需要先安装 [Microsoft Windows SDK for Windows 7 and .NET Framework 4
 ](https://www.microsoft.com/en-us/download/details.aspx?id=8279)
+* http://blog.csdn.net/ty_0930/article/details/70184392
 
 > 对应的文章： [使用 webpack + react + redux + es6 开发组件化前端项目](https://segmentfault.com/a/1190000005969488)
 

--- a/build/webpack.config.js
+++ b/build/webpack.config.js
@@ -2,6 +2,7 @@ var webpack = require('webpack');
 var ExtractTextPlugin = require('extract-text-webpack-plugin');
 var WebpackMd5Hash = require('webpack-md5-hash');
 var HashedModuleIdsPlugin = require('./HashedModuleIdsPlugin');
+var path = require('path');
 
 // 辅助函数
 var utils = require('./utils');
@@ -11,7 +12,9 @@ var pickFiles = utils.pickFiles;
 // 项目根路径
 var ROOT_PATH = fullPath('../');
 // 项目源码路径
-var SRC_PATH = ROOT_PATH + '/src';
+//windows has "" as path separator
+// var SRC_PATH = ROOT_PATH + '/src';
+var SRC_PATH = path.join(ROOT_PATH, 'src');
 // 产出路径
 var DIST_PATH = ROOT_PATH + '/dist';
 


### PR DESCRIPTION
1.在README.md文件中添加Windows环境下node-sass安装失败解决方案(您提供的方法没有解决)
2.修改webpack.config.js文件中SRC_PATH的拼接方法,使项目在macOS能正常运行的同时也能在Windows环境下编译成功(现在windows环境下会报错误Cannot resolve 'file' or 'directory' ./../../../node_modules/webpack/buildin/module.js)